### PR TITLE
Add gulp as script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ $ npm run pack-desktop
 This boilerplate uses gulp to build. Watch command is also available if you develop it continiously:
 
 ```sh
-gulp watch
+npm run gulp watch
 ```
 
 Minification is turned off by default. Use `--minify` flag to activate it:
 
 ```sh
-gulp build --minify
+npm run gulp build --minify
 ```
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "postinstall": "typings install",
     "build": "gulp build",
     "clean": "shx rm -Rf build/",
+    "gulp": "gulp",
     "tsc": "tsc",
     "typings": "typings",
     "lite": "lite-server",


### PR DESCRIPTION
This makes it easier to run the build if you don't happen to have gulp installed globally.
